### PR TITLE
add go modules support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Vendored dependencies
 vendor
+go.mod
+go.sum


### PR DESCRIPTION
This PR adds the go modules support to the project with `go mod init`. It allows developing outside the `$GOPATH`. For more info about go modules: [https://github.com/golang/go/wiki/Modules](https://github.com/golang/go/wiki/Modules)